### PR TITLE
Make it clear how to work with multiple live pages per controller or application

### DIFF
--- a/app/controllers/game_controller.rb
+++ b/app/controllers/game_controller.rb
@@ -9,7 +9,7 @@ class GameController < ApplicationController
 
   skip_before_action :verify_authenticity_token, only: :live
 
-  def live
+  def index_live
     self.response = Async::WebSocket::Adapters::Rails.open(request) do |connection|
       Live::Page.new(RESOLVER).run(connection)
     end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,4 +3,5 @@
 // import "controllers"
 
 import {Live} from "@socketry/live"
-window.live = Live.start()
+
+window.Live = Live

--- a/app/views/game/index.html.xrb
+++ b/app/views/game/index.html.xrb
@@ -1,1 +1,7 @@
 #{@view}
+
+<script>
+  var live = window.Live.start({
+    path: "index_live",
+  })
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,5 @@ Rails.application.routes.draw do
   root "game#index"
 
   # The websocket route for the game:
-  match "live", to: "game#live", via: [:get, :connect]
+  match "index_live", to: "game#index_live", via: [:get, :connect]
 end


### PR DESCRIPTION
Posting this PR as I found it non-obvious how to do multiple actions within a controller or application.

Not sure if making these changes to this repo is the perfect solution for this. It likely deserves some documentation somewhere. Maybe the `live` ruby gem documentation getting started page (https://socketry.github.io/live/guides/getting-started/index.html) should contain information regarding live.js javascript integration requirements (Ex. calling `Live.start()`)

Also would generally prefer if Live.js didnt try to hide the `path` argument by having a default. I think it would be better if it was explicit, or we should at least encourage users to be explicit in the javascript documentation examples even if the default must remain.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Clarification
- Suggestion

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
